### PR TITLE
Removed trailing space from useLogs.js import path

### DIFF
--- a/composables/useVisualize.js
+++ b/composables/useVisualize.js
@@ -1,5 +1,5 @@
 import { useStorage } from "@vueuse/core";
-import { info, debug, error, assert, TODO } from "@/composables/useLogs.js ";
+import { info, debug, error, assert, TODO } from "@/composables/useLogs.js";
 
 const bVisualizeAll = useStorage("vue-app-visualize-all", false);
 const bVisualizeElements = useStorage("vue-app-visualize-frame", false);


### PR DESCRIPTION
Noticed an error when running 'npm run generate'. Turned out to just be an extra space in the useLogs.js import filepath.